### PR TITLE
Pin postgres image to :18 and update the mounted volume path

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,14 +24,14 @@ services:
       redis:
         condition: service_healthy
   db:
-    image: postgres
+    image: postgres:18
     environment:
       POSTGRES_USER: shadybucks
       POSTGRES_PASSWORD: N9aj8vtIaaYsAY52gdSXjOdgdzY8BTiN
       POSTGRES_DB: shadybucks
     volumes:
       - ./srv/data/postgres.sql:/docker-entrypoint-initdb.d/00-create_db.sql
-      - shadybucks-db:/var/lib/postgresql/data
+      - shadybucks-db:/var/lib/postgresql
     healthcheck:
       test: [ "CMD", "pg_isready", "-q", "-d", "shadybucks", "-U", "shadybucks" ]
       timeout: 45s


### PR DESCRIPTION
the postgres image in `docker-compose.yml` is not pinned to a specific postgres version. Since postgres 18, the expected volume mount path has changed. running `docker-compose up` will fail to start postgres:

```
db-1            | Error: in 18+, these Docker images are configured to store database data in a
db-1            |        format which is compatible with "pg_ctlcluster" (specifically, using
db-1            |        major-version-specific directory names).  This better reflects how
db-1            |        PostgreSQL itself works, and how upgrades are to be performed.
db-1            |
db-1            |        See also https://github.com/docker-library/postgres/pull/1259
db-1            |
db-1            |        Counter to that, there appears to be PostgreSQL data in:
db-1            |          /var/lib/postgresql/data (unused mount/volume)
db-1            |
db-1            |        This is usually the result of upgrading the Docker image without
db-1            |        upgrading the underlying database using "pg_upgrade" (which requires both
db-1            |        versions).
db-1            |
db-1            |        The suggested container configuration for 18+ is to place a single mount
db-1            |        at /var/lib/postgresql which will then place PostgreSQL data in a
db-1            |        subdirectory, allowing usage of "pg_upgrade --link" without mount point
db-1            |        boundary issues.
db-1            |
db-1            |        See https://github.com/docker-library/postgres/issues/37 for a (long)
db-1            |        discussion around this process, and suggestions for how to do so.
```

this fixes by:
1. Pinning postgres to :18 so future updates dont create problems
2. fixing the mount path